### PR TITLE
partly fixes #1. Check path of pinentry.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/gador/pinentry
+module github.com/gopasspw/pinentry
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/gopasspw/pinentry
+module github.com/gador/pinentry
 
 go 1.16

--- a/pinentry_others.go
+++ b/pinentry_others.go
@@ -2,12 +2,18 @@
 
 package pinentry
 
-import "github.com/gopasspw/pinentry/gpgconf"
+import (
+	"github.com/gopasspw/pinentry/gpgconf"
+	"os/exec"
+)
 
 // GetBinary returns the binary name
 func GetBinary() string {
 	if p, err := gpgconf.Path("pinentry"); err == nil && p != "" {
-		return p
+		// check, whether the returned path acutally exists
+		if _, err := exec.LookPath(p); err == nil {
+			return p
+		}
 	}
 	return "pinentry"
 }


### PR DESCRIPTION
I have some problems with [Yubikey-agent](https://github.com/FiloSottile/yubikey-agent) since it relies on this library to get the binary of pinentry. 
In my system (NixOS) the binary path of pinentry as it is returned by gpgconf isn't correct. 
As described in #1 this isn't an isolated problem. This is a small fix to check, whether the path to the pinentry binary exists and if it doesn't returns "pinentry". 
